### PR TITLE
Pinning covalent-aws-plugins to 0.1.0rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updated requirements.txt to pin aws executor plugins to pre-release version 0.1.0rc0
+
 ### Tests
 
 - Updated tests for ECS Executor now using AWSExecutor base class

--- a/covalent_ecs_plugin/ecs.py
+++ b/covalent_ecs_plugin/ecs.py
@@ -172,7 +172,7 @@ class ECSExecutor(AWSExecutor):
             function_file.flush()
             s3.upload_file(function_file.name, self.s3_bucket_name, s3_object_filename)
 
-    async def submit_task(self, task_metadata: Dict, identity: Dict) -> None:
+    async def submit_task(self, task_metadata: Dict, identity: Dict) -> str:
 
         dispatch_id = task_metadata["dispatch_id"]
         node_id = task_metadata["node_id"]
@@ -330,6 +330,7 @@ class ECSExecutor(AWSExecutor):
         Returns:
             None
         """
+        self._debug_log(f"Polling task with arn {task_arn}...")
         status, exit_code = await self.get_status(task_arn)
 
         while status != "STOPPED":
@@ -359,8 +360,6 @@ class ECSExecutor(AWSExecutor):
 
         Args:
             task_metadata: Dictionary containing the task dispatch_id and node_id
-            task_arn: AWS Identifier for the ECS task
-
         Returns:
             result: The task's result, as a Python object.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.24.35
-git+https://github.com/AgnostiqHQ/covalent-aws-plugins.git@develop#egg=covalent-aws-plugins
+covalent-aws-plugins==0.1.0rc0
 docker==5.0.3

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -241,7 +241,7 @@ class TestECSExecutor:
 
     @pytest.mark.asyncio
     async def test_run(self, mocker, mock_executor):
-        """Test the execute method."""
+        """Test the run method."""
 
         MOCK_IDENTITY = {"Account": 1234}
         mock_executor.vcpu = 1
@@ -251,7 +251,6 @@ class TestECSExecutor:
             return x
 
         boto3_mock = mocker.patch("covalent_ecs_plugin.ecs.boto3")
-        ecs_client_mock = boto3_mock.Session().client()
 
         upload_task_mock = mocker.patch("covalent_ecs_plugin.ecs.ECSExecutor._upload_task")
         validate_credentials_mock = mocker.patch(


### PR DESCRIPTION
Pinning covalent-aws-plugins to 0.1.0rc0
Updated some outdated docstrings

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
