### PR TITLE
Falling back to config file defaults in using executor class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-### Fixed
+### Changed
 
 - Falling back to config file defaults when using executor via instantiation of executor class
+- Removed redundant `ecr_repo_name` config attribute
 
 ## [0.14.0] - 2022-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Falling back to config file defaults when using executor via instantiation of executor class
+
 ## [0.14.0] - 2022-09-30
 
 ### Added

--- a/covalent_ecs_plugin/ecs.py
+++ b/covalent_ecs_plugin/ecs.py
@@ -146,27 +146,6 @@ class ECSExecutor(AWSExecutor):
                 f"{self.ecs_task_security_group_id} is not a valid security group id. Please set a valid security group id either in the ECS executor definition or in the Covalent config file."
             )
 
-        config = {
-            "profile": self.profile,
-            "region": self.region,
-            "credentials": self.credentials_file,
-            "s3_bucket_name": self.s3_bucket_name,
-            "ecs_cluster_name": self.ecs_cluster_name,
-            "ecs_task_family_name": self.ecs_task_family_name,
-            "ecs_task_role_name": self.ecs_task_role_name,
-            "ecs_task_subnet_id": self.ecs_task_subnet_id,
-            "ecs_task_security_group_id": self.ecs_task_security_group_id,
-            "log_group_name": self.log_group_name,
-            "execution_role": self.execution_role,
-            "poll_freq": self.poll_freq,
-            "vcpu": self.vcpu,
-            "memory": self.memory,
-            "cache_dir": self.cache_dir,
-            "_cwd": self._cwd,
-        }
-        self._debug_log("Starting ECS Executor with config:")
-        app_log.debug(config)
-
     async def _upload_task(self, function, args, kwargs, task_metadata) -> None:
 
         dispatch_id = task_metadata["dispatch_id"]
@@ -320,7 +299,7 @@ class ECSExecutor(AWSExecutor):
             for task in tasks:
                 if task["taskArn"] == task_arn:
                     status = task["lastStatus"]
-                    self._debug_log(f"Got status of task {task_arn}: ${status}")
+                    self._debug_log(f"Got status of task {task_arn}: {status}")
                     try:
                         exit_code = int(task["containers"][0]["exitCode"])
                     except KeyError:

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -37,7 +37,6 @@ class TestECSExecutor:
 
     MOCK_PROFILE = "my_profile"
     MOCK_S3_BUCKET_NAME = "s3-bucket"
-    MOCK_ECR_REPO_NAME = "ecs-repo"
     MOCK_ECS_CLUSTER_NAME = "ecs-cluster"
     MOCK_ECS_TASK_FAMILY_NAME = "task-family-name"
     MOCK_ECS_EXECUTION_ROLE = "task-execution-role"
@@ -71,7 +70,6 @@ class TestECSExecutor:
         config = {
             "profile": self.MOCK_PROFILE,
             "s3_bucket_name": self.MOCK_S3_BUCKET_NAME,
-            "ecr_repo_name": self.MOCK_ECR_REPO_NAME,
             "ecs_cluster_name": self.MOCK_ECS_CLUSTER_NAME,
             "ecs_task_family_name": self.MOCK_ECS_TASK_FAMILY_NAME,
             "ecs_task_execution_role_name": self.MOCK_ECS_EXECUTION_ROLE,
@@ -105,7 +103,6 @@ class TestECSExecutor:
 
         assert executor.profile == self.MOCK_PROFILE
         assert executor.s3_bucket_name == self.MOCK_S3_BUCKET_NAME
-        assert executor.ecr_repo_name == self.MOCK_ECR_REPO_NAME
         assert executor.ecs_task_family_name == self.MOCK_ECS_TASK_FAMILY_NAME
         assert executor.execution_role == self.MOCK_ECS_EXECUTION_ROLE
         assert executor.ecs_task_role_name == self.MOCK_ECS_TASK_ROLE_NAME


### PR DESCRIPTION
Falling back to config file defaults when using executor via instantiation of executor class

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
