### PR TITLE
update version change for aws provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updated the terraform provider version for AWS to 5.17.0 (ecs plugin)
+- Disabled `enable_nat_gateway` on the vpc module, since it was throwing error from the respective module
+
 ## [0.31.0] - 2023-09-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the terraform provider version for AWS to 5.17.0 (ecs plugin)
 - Disabled `enable_nat_gateway` on the vpc module, since it was throwing error from the respective module
 
+### Added
+- Added ownership controls for S3 bucket for supporting S3 bucket ACL
+
 ## [0.31.0] - 2023-09-20
 
 ### Changed

--- a/covalent_ecs_plugin/assets/infra/main.tf
+++ b/covalent_ecs_plugin/assets/infra/main.tf
@@ -23,9 +23,18 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
+resource "aws_s3_bucket_ownership_controls" "ownership_controls" {
   bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.ownership_controls]
+  bucket     = aws_s3_bucket.bucket.id
+  acl        = "private"
 }
 
 resource "aws_ecr_repository" "ecr_repository" {

--- a/covalent_ecs_plugin/assets/infra/networking.tf
+++ b/covalent_ecs_plugin/assets/infra/networking.tf
@@ -29,7 +29,7 @@ module "vpc" {
   ]
   private_subnets = []
 
-  enable_nat_gateway   = true
+  enable_nat_gateway   = false
   single_nat_gateway   = false
   enable_dns_hostnames = true
 }

--- a/covalent_ecs_plugin/assets/infra/versions.tf
+++ b/covalent_ecs_plugin/assets/infra/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.23"
+      version = "5.17.0"
     }
   }
 }


### PR DESCRIPTION
Changed:
- Updated the terraform provider version for AWS to 5.17.0 (ecs plugin)
- Disabled `enable_nat_gateway` on the vpc module, since it was throwing errors from the respective module

Added:
- Added ownership controls for S3 bucket for supporting S3 bucket ACL
